### PR TITLE
update dependency on php_codesniffer to ^3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
     "description" : "Custom code style for php and nette based projects.",
     "version": "0.1.0",
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "license": "",
     "require": {
-        "php": ">=5.4.0",
-        "squizlabs/php_codesniffer": "^2.6"
+        "squizlabs/php_codesniffer": "^3.4"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/src/Smartsupp/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Smartsupp/Sniffs/Classes/ClassDeclarationSniff.php
@@ -2,8 +2,8 @@
 
 namespace Smartsupp\Sniffs\Classes;
 
-use PEAR_Sniffs_Classes_ClassDeclarationSniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Classes\ClassDeclarationSniff as PEARClassDeclarationSniff;
+use PHP_CodeSniffer\Files\File;
 
 /**
  * Rules (new to parent class):
@@ -14,7 +14,7 @@ use PHP_CodeSniffer_File;
  * - Opening brace can be followed with simple comment without new line.
  * - Opening brace can be followed with constant or use without new line.
  */
-final class ClassDeclarationSniff extends PEAR_Sniffs_Classes_ClassDeclarationSniff
+final class ClassDeclarationSniff extends PEARClassDeclarationSniff
 {
 
 	/** @var int */
@@ -27,7 +27,7 @@ final class ClassDeclarationSniff extends PEAR_Sniffs_Classes_ClassDeclarationSn
 	/**
 	 * {@inheritdoc}
 	 */
-	public function process(PHP_CodeSniffer_File $file, $position)
+	public function process(File $file, $position)
 	{
 		parent::process($file, $position);
 		$this->emptyLinesAfterOpeningBrace = (int) $this->emptyLinesAfterOpeningBrace;
@@ -38,7 +38,7 @@ final class ClassDeclarationSniff extends PEAR_Sniffs_Classes_ClassDeclarationSn
 	}
 
 
-	private function processOpen(PHP_CodeSniffer_File $file, $position)
+	private function processOpen(File $file, $position)
 	{
 		$tokens = $file->getTokens();
 		$openingBracePosition = $tokens[$position]['scope_opener'];
@@ -61,7 +61,7 @@ final class ClassDeclarationSniff extends PEAR_Sniffs_Classes_ClassDeclarationSn
 	}
 
 
-	private function processClose(PHP_CodeSniffer_File $file, $position)
+	private function processClose(File $file, $position)
 	{
 		$tokens = $file->getTokens();
 		$closeBracePosition = $tokens[$position]['scope_closer'];
@@ -79,7 +79,7 @@ final class ClassDeclarationSniff extends PEAR_Sniffs_Classes_ClassDeclarationSn
 	}
 
 
-	private function getNextTokenAfterOpeningBrace(PHP_CodeSniffer_File $file, $position)
+	private function getNextTokenAfterOpeningBrace(File $file, $position)
 	{
 		$tokens = $file->getTokens();
 		$nextContent = $file->findNext(T_WHITESPACE, ($position + 1), NULL, TRUE);
@@ -87,7 +87,7 @@ final class ClassDeclarationSniff extends PEAR_Sniffs_Classes_ClassDeclarationSn
 	}
 
 
-	private function getEmptyLinesAfterOpeningBrace(PHP_CodeSniffer_File $file, $position)
+	private function getEmptyLinesAfterOpeningBrace(File $file, $position)
 	{
 		$tokens = $file->getTokens();
 		$nextContent = $file->findNext(T_WHITESPACE, ($position + 1), NULL, TRUE);
@@ -95,7 +95,7 @@ final class ClassDeclarationSniff extends PEAR_Sniffs_Classes_ClassDeclarationSn
 	}
 
 
-	private function getEmptyLinesBeforeClosingBrace(PHP_CodeSniffer_File $file, $position)
+	private function getEmptyLinesBeforeClosingBrace(File $file, $position)
 	{
 		$tokens = $file->getTokens();
 		$prevContent = $file->findPrevious(T_WHITESPACE, ($position - 1), NULL, TRUE);

--- a/src/Smartsupp/Sniffs/WhiteSpace/BetweenMethodSpacingSniff.php
+++ b/src/Smartsupp/Sniffs/WhiteSpace/BetweenMethodSpacingSniff.php
@@ -2,8 +2,8 @@
 
 namespace Smartsupp\Sniffs\WhiteSpace;
 
-use PHP_CodeSniffer_File;
-use Squiz_Sniffs_WhiteSpace_FunctionSpacingSniff;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionSpacingSniff;
+use PHP_CodeSniffer\Files\File;
 
 /**
  * Rules:
@@ -14,7 +14,7 @@ use Squiz_Sniffs_WhiteSpace_FunctionSpacingSniff;
  * - Method is the last in the class, followed by close bracket.
  * - Method is used inside interface.
  */
-final class BetweenMethodSpacingSniff extends Squiz_Sniffs_WhiteSpace_FunctionSpacingSniff
+final class BetweenMethodSpacingSniff extends FunctionSpacingSniff
 {
 
 	/** @var int */
@@ -26,7 +26,7 @@ final class BetweenMethodSpacingSniff extends Squiz_Sniffs_WhiteSpace_FunctionSp
 	/** @var array */
 	private $tokens;
 
-	/** @var PHP_CodeSniffer_File */
+	/** @var File */
 	private $file;
 
 
@@ -42,7 +42,7 @@ final class BetweenMethodSpacingSniff extends Squiz_Sniffs_WhiteSpace_FunctionSp
 	/**
 	 * {@inheritdoc}
 	 */
-	public function process(PHP_CodeSniffer_File $file, $position)
+	public function process(File $file, $position)
 	{
 		// Fix type
 		$this->blankLinesBetweenMethods = (int) $this->blankLinesBetweenMethods;


### PR DESCRIPTION
seems to work fine, only exception i encountered is, rather unlucky, removal of Squiz.PHP.ForbiddenFunctions sniff.
If smartlook is using this sniff, they will have to replace the line
```
<rule ref="Squiz.PHP.ForbiddenFunctions"/>
```
with
```
<rule ref="Generic.PHP.ForbiddenFunctions">
  <properties>
    <property name="forbiddenFunctions" type="array" value="sizeof=>count,delete=>unset,print=>echo,is_null=>null,create_function=>null" />
  </properties>
</rule>
```
in their ruleset.xml

And of course if smartlook is defining new classes implementing interfaces or extending classes from the codesniffer they will have to follow the guideline for migration:
https://github.com/squizlabs/PHP_CodeSniffer/wiki/Version-3.0-Upgrade-Guide
Mostly moving from underscore names to namespaced names.
